### PR TITLE
feat(gatsby-source-drupal): Add multilingual support by prefixing nodes not in the default language with their langcode

### DIFF
--- a/packages/gatsby-source-drupal/src/gatsby-node.js
+++ b/packages/gatsby-source-drupal/src/gatsby-node.js
@@ -108,7 +108,7 @@ exports.sourceNodes = async (
   fastBuilds = fastBuilds || false
   if (fastBuilds) {
     let lastFetched =
-      store.getState().status.plugins?.[`gatsby-source-drupal-${languagePrefix}`]?.lastFetched ??
+      store.getState().status.plugins?.[`gatsby-source-drupal`]?.lastFetched ??
       0
 
     const drupalFetchIncrementalActivity = reporter.activityTimer(

--- a/packages/gatsby-source-drupal/src/gatsby-node.js
+++ b/packages/gatsby-source-drupal/src/gatsby-node.js
@@ -108,7 +108,7 @@ exports.sourceNodes = async (
   fastBuilds = fastBuilds || false
   if (fastBuilds) {
     let lastFetched =
-      store.getState().status.plugins?.[`gatsby-source-drupal-${languagePrefix}`]?.lastFetched ??
+      store.getState().status.plugins?.[`gatsby-source-drupal`]?.[`lastFetched${languagePrefix}`] ??
       0
 
     const drupalFetchIncrementalActivity = reporter.activityTimer(
@@ -132,7 +132,7 @@ exports.sourceNodes = async (
       if (data.data.status === -1) {
         // The incremental data is expired or this is the first fetch.
         reporter.info(`Unable to pull incremental data changes from Drupal`)
-        setPluginStatus({ lastFetched: data.data.timestamp })
+        setPluginStatus({ [`lastFetched${languagePrefix}`]: data.data.timestamp })
         requireFullRebuild = true
       } else {
         // Touch nodes so they are not garbage collected by Gatsby.
@@ -175,7 +175,7 @@ exports.sourceNodes = async (
           }
         }
 
-        setPluginStatus({ lastFetched: data.data.timestamp })
+        setPluginStatus({ [`lastFetched${languagePrefix}`]: data.data.timestamp })
       }
     } catch (e) {
       gracefullyRethrow(drupalFetchIncrementalActivity, e)

--- a/packages/gatsby-source-drupal/src/gatsby-node.js
+++ b/packages/gatsby-source-drupal/src/gatsby-node.js
@@ -298,7 +298,7 @@ exports.sourceNodes = async (
     if (!contentType) return
     _.each(contentType.data, datum => {
       if (!datum) return
-      if (languagePrefix !== '' && !datum.attributes.langcode !== languagePrefix) return
+      if (languagePrefix !== '' && datum.attributes.langcode !== languagePrefix) return
       const node = nodeFromData(datum, createNodeId, languagePrefix)
       nodes.set(node.id, node)
     })

--- a/packages/gatsby-source-drupal/src/gatsby-node.js
+++ b/packages/gatsby-source-drupal/src/gatsby-node.js
@@ -108,7 +108,7 @@ exports.sourceNodes = async (
   fastBuilds = fastBuilds || false
   if (fastBuilds) {
     let lastFetched =
-      store.getState().status.plugins?.[`gatsby-source-drupal`]?.lastFetched ??
+      store.getState().status.plugins?.[`gatsby-source-drupal-${languagePrefix}`]?.lastFetched ??
       0
 
     const drupalFetchIncrementalActivity = reporter.activityTimer(

--- a/packages/gatsby-source-drupal/src/gatsby-node.js
+++ b/packages/gatsby-source-drupal/src/gatsby-node.js
@@ -298,6 +298,7 @@ exports.sourceNodes = async (
     if (!contentType) return
     _.each(contentType.data, datum => {
       if (!datum) return
+      if (languagePrefix !== '' && !datum.attributes.langcode !== languagePrefix) return
       const node = nodeFromData(datum, createNodeId, languagePrefix)
       nodes.set(node.id, node)
     })

--- a/packages/gatsby-source-drupal/src/gatsby-node.js
+++ b/packages/gatsby-source-drupal/src/gatsby-node.js
@@ -49,6 +49,8 @@ exports.sourceNodes = async (
     disallowedLinkTypes,
     skipFileDownloads,
     fastBuilds,
+    language,
+    defaultLanguage,
   } = pluginOptions
   const { createNode, setPluginStatus, touchNode } = actions
 
@@ -203,6 +205,14 @@ exports.sourceNodes = async (
   // Default skipFileDownloads to false.
   skipFileDownloads = skipFileDownloads || false
 
+  // Default language to `en`
+  language = language || `en`
+
+  // Default defaultLanguage to `en`
+  defaultLanguage = defaultLanguage || `en`
+
+  const languagePrefix = defaultLanguage !== language ? language : ``
+
   // Fetch articles.
   reporter.info(`Starting to fetch all data from Drupal`)
 
@@ -210,7 +220,7 @@ exports.sourceNodes = async (
 
   let allData
   try {
-    const data = await axios.get(`${baseUrl}/${apiBase}`, {
+    const data = await axios.get(`${baseUrl}/${languagePrefix}/${apiBase}`, {
       auth: basicAuth,
       headers,
       params,
@@ -292,7 +302,7 @@ exports.sourceNodes = async (
     if (!contentType) return
     _.each(contentType.data, datum => {
       if (!datum) return
-      const node = nodeFromData(datum, createNodeId)
+      const node = nodeFromData(datum, createNodeId, languagePrefix)
       nodes.set(node.id, node)
     })
   })
@@ -302,7 +312,7 @@ exports.sourceNodes = async (
     handleReferences(node, {
       getNode: nodes.get.bind(nodes),
       createNodeId,
-    })
+    }, languagePrefix)
   })
 
   if (skipFileDownloads) {

--- a/packages/gatsby-source-drupal/src/normalize.js
+++ b/packages/gatsby-source-drupal/src/normalize.js
@@ -1,12 +1,14 @@
 const { URL } = require(`url`)
 const { createRemoteFileNode } = require(`gatsby-source-filesystem`)
 
-const nodeFromData = (datum, createNodeId) => {
+const { createNamespacedNodeId } = require(`./utils`)
+
+const nodeFromData = (datum, createNodeId, languagePrefix) => {
   const { attributes: { id: _attributes_id, ...attributes } = {} } = datum
   const preservedId =
     typeof _attributes_id !== `undefined` ? { _attributes_id } : {}
   return {
-    id: createNodeId(datum.id),
+    id: createNodeId(createNamespacedNodeId(datum.id, languagePrefix)),
     drupal_id: datum.id,
     parent: null,
     drupal_parent_menu_item: attributes.parent,

--- a/packages/gatsby-source-drupal/src/normalize.js
+++ b/packages/gatsby-source-drupal/src/normalize.js
@@ -1,7 +1,11 @@
 const { URL } = require(`url`)
 const { createRemoteFileNode } = require(`gatsby-source-filesystem`)
 
-const { createNamespacedNodeId } = require(`./utils`)
+const createNamespacedNodeId = (id, language) => language
+  ? `${language}_${id}`
+  : id
+
+exports.createNamespacedNodeId = createNamespacedNodeId
 
 const nodeFromData = (datum, createNodeId, languagePrefix) => {
   const { attributes: { id: _attributes_id, ...attributes } = {} } = datum

--- a/packages/gatsby-source-drupal/src/utils.js
+++ b/packages/gatsby-source-drupal/src/utils.js
@@ -4,7 +4,13 @@ const { nodeFromData, downloadFile, isFileNode } = require(`./normalize`)
 const backRefsNamesLookup = new WeakMap()
 const referencedNodesLookup = new WeakMap()
 
-const handleReferences = (node, { getNode, createNodeId }) => {
+const createNamespacedNodeId = (id, language) => language
+  ? `${language}_${id}`
+  : id
+
+exports.createNamespacedNodeId = createNamespacedNodeId
+
+const handleReferences = (node, { getNode, createNodeId }, languagePrefix) => {
   const relationships = node.relationships
 
   if (node.drupal_relationships) {
@@ -15,7 +21,7 @@ const handleReferences = (node, { getNode, createNodeId }) => {
       if (_.isArray(v.data)) {
         relationships[nodeFieldName] = _.compact(
           v.data.map(data => {
-            const referencedNodeId = createNodeId(data.id)
+            const referencedNodeId = createNodeId(createNamespacedNodeId(data.id, languagePrefix))
             if (!getNode(referencedNodeId)) {
               return null
             }
@@ -35,7 +41,7 @@ const handleReferences = (node, { getNode, createNodeId }) => {
           node[k] = meta
         }
       } else {
-        const referencedNodeId = createNodeId(v.data.id)
+        const referencedNodeId = createNodeId(createNamespacedNodeId(v.data.id, languagePrefix))
         if (getNode(referencedNodeId)) {
           relationships[nodeFieldName] = referencedNodeId
           referencedNodes.push(referencedNodeId)

--- a/packages/gatsby-source-drupal/src/utils.js
+++ b/packages/gatsby-source-drupal/src/utils.js
@@ -98,6 +98,8 @@ const handleWebhookUpdate = async (
   const { createNode } = actions
   const { skipFileDownloads, languagePrefix } = pluginOptions
 
+  if (languagePrefix !== '' && nodeToUpdate.attributes.langcode !== languagePrefix) return
+
   const newNode = nodeFromData(nodeToUpdate, createNodeId, languagePrefix)
 
   const nodesToUpdate = [newNode]
@@ -135,7 +137,7 @@ const handleWebhookUpdate = async (
       referencedNode.relationships[
         nodeFieldName
       ] = referencedNode.relationships[nodeFieldName].filter(
-        id => id !== newNode.id
+        id => createNamespacedNodeId(id, languagePrefix) !== newNode.id
       )
     })
 


### PR DESCRIPTION
## Description

We're currently using `gatsby-source-drupal` to pull content from our D8 site and we got stuck trying to pull content from another language because it gets overwritten by the last source plugin in the list. eg. `gatsby-config.js`

```js
...
{
  resolve: `gatsby-source-drupal`,
  options: {
    baseUrl: `http://example.com`,
  },
},
{
  resolve: `gatsby-source-drupal`,
  options: {
    baseUrl: `http://example.com/es`,
  },
},
...
```

## Documentation

- [ ] ~Add information about the new parameters `language` and `defaultLanguage` to the README.md~
- [ ] Add information about the new parameter `languagePrefix` to the README.md

## Related Issues

Addresses https://github.com/gatsbyjs/gatsby/issues/10020