### PR TITLE
fix: extract href from link objects when fetching translation settings

### DIFF
--- a/packages/gatsby-source-drupal/src/gatsby-node.js
+++ b/packages/gatsby-source-drupal/src/gatsby-node.js
@@ -1,7 +1,12 @@
 const axios = require(`axios`)
 const _ = require(`lodash`)
 
-const { nodeFromData, downloadFile, isFileNode } = require(`./normalize`)
+const {
+  nodeFromData,
+  downloadFile,
+  isFileNode,
+  getHref,
+} = require(`./normalize`)
 const {
   handleReferences,
   handleWebhookUpdate,
@@ -257,7 +262,7 @@ exports.sourceNodes = async (
         const getNext = async (url, data = []) => {
           if (typeof url === `object`) {
             // url can be string or object containing href field
-            url = url.href
+            url = getHref(url)
 
             // Apply any filters configured in gatsby-config.js. Filters
             // can be any valid JSON API filter query string.

--- a/packages/gatsby-source-drupal/src/gatsby-node.js
+++ b/packages/gatsby-source-drupal/src/gatsby-node.js
@@ -262,7 +262,7 @@ exports.sourceNodes = async (
         const getNext = async (url, data = []) => {
           if (typeof url === `object`) {
             // url can be string or object containing href field
-            url = getHref(url)
+            url = url.href
 
             // Apply any filters configured in gatsby-config.js. Filters
             // can be any valid JSON API filter query string.

--- a/packages/gatsby-source-drupal/src/gatsby-node.js
+++ b/packages/gatsby-source-drupal/src/gatsby-node.js
@@ -5,7 +5,6 @@ const {
   nodeFromData,
   downloadFile,
   isFileNode,
-  getHref,
 } = require(`./normalize`)
 const {
   handleReferences,

--- a/packages/gatsby-source-drupal/src/normalize.js
+++ b/packages/gatsby-source-drupal/src/normalize.js
@@ -1,6 +1,15 @@
 const { URL } = require(`url`)
 const { createRemoteFileNode } = require(`gatsby-source-filesystem`)
 
+const getHref = link => {
+  if (typeof link === `object`) {
+    return link.href
+  }
+  return link
+}
+
+exports.getHref = getHref
+
 const nodeFromData = (datum, createNodeId) => {
   const { attributes: { id: _attributes_id, ...attributes } = {} } = datum
   const preservedId =
@@ -58,7 +67,7 @@ exports.downloadFile = async (
             }
           : {}
       fileNode = await createRemoteFileNode({
-        url: url.href,
+        url: getHref(url),
         store,
         cache,
         createNode,

--- a/packages/gatsby-source-drupal/src/normalize.js
+++ b/packages/gatsby-source-drupal/src/normalize.js
@@ -67,7 +67,7 @@ exports.downloadFile = async (
             }
           : {}
       fileNode = await createRemoteFileNode({
-        url,
+        url: url.href,
         store,
         cache,
         createNode,

--- a/packages/gatsby-source-drupal/src/normalize.js
+++ b/packages/gatsby-source-drupal/src/normalize.js
@@ -67,7 +67,7 @@ exports.downloadFile = async (
             }
           : {}
       fileNode = await createRemoteFileNode({
-        url: getHref(url),
+        url,
         store,
         cache,
         createNode,

--- a/packages/gatsby-source-drupal/src/utils.js
+++ b/packages/gatsby-source-drupal/src/utils.js
@@ -1,16 +1,14 @@
 const _ = require(`lodash`)
 const axios = require(`axios`)
-const { nodeFromData, downloadFile, isFileNode } = require(`./normalize`)
+const {
+  nodeFromData,
+  downloadFile,
+  isFileNode,
+  getHref,
+} = require(`./normalize`)
 
 const backRefsNamesLookup = new WeakMap()
 const referencedNodesLookup = new WeakMap()
-
-const getHref = link => {
-  if (typeof link === `object`) {
-    return link.href
-  }
-  return link
-}
 
 const fetchLanguageConfig = async ({
   translation,

--- a/packages/gatsby-source-drupal/src/utils.js
+++ b/packages/gatsby-source-drupal/src/utils.js
@@ -5,6 +5,13 @@ const { nodeFromData, downloadFile, isFileNode } = require(`./normalize`)
 const backRefsNamesLookup = new WeakMap()
 const referencedNodesLookup = new WeakMap()
 
+const getHref = link => {
+  if (typeof link === `object`) {
+    return link.href
+  }
+  return link
+}
+
 const fetchLanguageConfig = async ({
   translation,
   baseUrl,
@@ -35,7 +42,7 @@ const fetchLanguageConfig = async ({
     availableLanguagesResponses = availableLanguagesResponses.concat(
       response.data.data
     )
-    next = response.data.links.next
+    next = getHref(response.data.links.next)
   }
 
   next = `${baseUrl}/${apiBase}/language_content_settings/language_content_settings?filter[language_alterable]=true`
@@ -49,7 +56,7 @@ const fetchLanguageConfig = async ({
     translatableEntitiesResponses = translatableEntitiesResponses.concat(
       response.data.data
     )
-    next = response.data.links.next
+    next = getHref(response.data.links.next)
   }
 
   const enabledLanguages = availableLanguagesResponses


### PR DESCRIPTION
## Description

The next link can be a string (in older versions of jsonapi) or an object. The language settings calls that return more than a page of results only work in the first case.

## Related Issues

https://github.com/gatsbyjs/gatsby/pull/26720