### PR TITLE
Update gatsby-node.js

### DIFF
--- a/packages/gatsby-source-drupal/src/gatsby-node.js
+++ b/packages/gatsby-source-drupal/src/gatsby-node.js
@@ -86,6 +86,12 @@ exports.sourceNodes = async (
       headers,
       params,
     })
+  
+    if(translation && !languageConfig.enabledLanguages.length) {
+      reporter.warn(
+          `The translation option is enabled but no enabled languages were retrieved from Drupal. Make sure your basicAuth credentials are populated with a user that has the "administer languages".`,
+      );
+    }
   }
 
   setPluginStatus({ languageConfig })

--- a/packages/gatsby-source-drupal/src/gatsby-node.js
+++ b/packages/gatsby-source-drupal/src/gatsby-node.js
@@ -89,7 +89,7 @@ exports.sourceNodes = async (
   
     if(translation && !languageConfig.enabledLanguages.length) {
       reporter.warn(
-          `The translation option is enabled but no enabled languages were retrieved from Drupal. Make sure your basicAuth credentials are populated with a user that has the "administer languages".`,
+          `The translation option is enabled but no enabled languages were retrieved from Drupal. Make sure your basicAuth credentials in the Gatsby config file are populated with a user that has the "administer languages" permission.`,
       );
     }
   }


### PR DESCRIPTION
Avoid silently failing to fetch enabled language from Drupal by adding a log to hint at what might be the problem
